### PR TITLE
Update Hook's Widget snippet

### DIFF
--- a/snippets/hook_widgets.code-snippets
+++ b/snippets/hook_widgets.code-snippets
@@ -5,7 +5,7 @@
         "description": "Creates a HookWidget class.",
         "body": [
             "class $1 extends HookWidget {",
-            "\tconst $1({Key? key}) : super(key: key);",
+            "\tconst $1({super.key});",
             "\n\t@override",
             "\tWidget build(BuildContext context) {",
             "\t\treturn const SizedBox();",
@@ -19,7 +19,7 @@
         "description": "Creates a StatefulHookWidget class.",
         "body": [
             "class $1 extends StatefulHookWidget {",
-            "\tconst $1({Key? key}) : super(key: key);",
+            "\tconst $1({super.key});",
             "\n\t@override",
             "\t_$1State createState() => _$1State();",
             "}\n",
@@ -37,7 +37,7 @@
         "description": "Creates a HookConsumerWidget class.",
         "body": [
             "class $1 extends HookConsumerWidget {",
-            "\tconst $1({Key? key}) : super(key: key);",
+            "\tconst $1({super.key});",
             "\n\t@override",
             "\tWidget build(BuildContext context, WidgetRef ref) {",
             "\t\treturn const SizedBox();",
@@ -51,7 +51,7 @@
         "description": "Creates a StatefulHookConsumerWidget class.",
         "body": [
             "class $1 extends StatefulHookConsumerWidget {",
-            "\tconst $1({Key? key}) : super(key: key);",
+            "\tconst $1({super.key});",
             "\n\t@override",
             "\tConsumerState<ConsumerStatefulWidget> createState() => _$1State();",
             "}\n",


### PR DESCRIPTION
Currently, if I use this snippet to create a Hook Widget, it doesn't show errors, but it's quite annoying because the lint showing messages that recommend using `{super.key}`. It's automatically corrected when I do formatting, but I thought it would be convenient to use `{super.key}` from the beginning.